### PR TITLE
Fix installation step for MacOS platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,85 +1,87 @@
-<div align="center">
-<h1>
-FireRedVAD: A SOTA Industrial-Grade
-<br>
-Voice Activity Detection & Audio Event Detection
-</h1>
-
-</div>
+<h1 align="center">FireRedVAD: A SOTA Industrial-Grade<br>Voice Activity Detection & Audio Event Detection</h1>
 
 [[Paper]](https://arxiv.org/pdf/2603.10420)
 [[Model🤗]](https://huggingface.co/FireRedTeam/FireRedVAD)
 [[Model🤖]](https://www.modelscope.cn/models/xukaituo/FireRedVAD)
 [[Demo]](https://huggingface.co/spaces/FireRedTeam/FireRedASR2S)
 
-
 FireRedVAD is a state-of-the-art (SOTA) industrial-grade Voice Activity Detection (VAD) and Audio Event Detection (AED) solution.
 FireRedVAD supports non-streaming/streaming VAD and non-streaming AED. It supports speech/singing/music detection in 100+ languages. Non-streaming VAD achieves 97.57% F1 on FLEURS-VAD-102, outperforming Silero-VAD, TEN-VAD, FunASR-VAD and WebRTC-VAD.
 
-
-
 ## 🔥 News
+
 - [2026.03.12] We release FireRedASR2S (including FireRedVAD) technical report. See [arXiv](https://arxiv.org/abs/2603.10420).
 - [2026.03.03] We release FireRedVAD as a standalone repository, along with model weights and inference code.
 - [2026.02.12] We release [FireRedASR2S](https://github.com/FireRedTeam/FireRedASR2S) (FireRedASR2-AED, FireRedVAD, FireRedLID, and FireRedPunc) with model weights and inference code.
 
-
-
 ## Quick Start
 
 ### Setup
+
 1. Create a clean Python environment:
-```bash
-$ conda create --name fireredvad python=3.10
-$ conda activate fireredvad
-$ git clone https://github.com/FireRedTeam/FireRedVAD.git
-$ cd FireRedVAD  # or fireredvad
-```
-Run Step 2 or Step 3 (choose one).
+
+    ```bash
+    conda create --name fireredvad python=3.10
+    conda activate fireredvad
+    git clone https://github.com/FireRedTeam/FireRedVAD.git
+    cd FireRedVAD  # or fireredvad
+    ```
+
+    Run Step 2 or Step 3 (choose one).
 
 2. (via pypi) Install dependencies and set up the environment
-```bash
-pip install fireredvad
 
-# With PyTorch (if not already installed)
-pip install fireredvad[gpu]
-```
+    ```bash
+    pip install fireredvad
+
+    # With PyTorch (if not already installed)
+    pip install fireredvad[gpu]
+    ```
 
 3. (from source) Install dependencies and set up PATH and PYTHONPATH:
-```bash
-$ pip install -r requirements.txt
-$ export PATH=$PWD/fireredvad/bin/:$PATH
-$ export PYTHONPATH=$PWD/:$PYTHONPATH
-```
 
+    ```bash
+    # for macos users
+    pip install -r requirements-macos-arm64.txt
+
+    # for windows/linux users with Nvidia GPUs
+    pip install -r requirements.txt 
+
+    export PATH=$PWD/fireredvad/bin/:$PATH
+    export PYTHONPATH=$PWD/:$PYTHONPATH
+    ```
 
 4. Download models:
-```bash
-# Download via ModelScope (recommended for users in China)
-pip install -U modelscope
-modelscope download --model xukaituo/FireRedVAD --local_dir ./pretrained_models/FireRedVAD
 
-# Download via Hugging Face
-pip install -U "huggingface_hub[cli]"
-huggingface-cli download FireRedTeam/FireRedVAD --local-dir ./pretrained_models/FireRedVAD
-```
+    ```bash
+    # Download via ModelScope (recommended for users in China)
+    pip install -U modelscope
+    modelscope download --model xukaituo/FireRedVAD --local_dir ./pretrained_models/FireRedVAD
+
+    # Download via Hugging Face
+    pip install -U "huggingface_hub[cli]"
+    huggingface-cli download FireRedTeam/FireRedVAD --local-dir ./pretrained_models/FireRedVAD
+    ```
 
 5. Convert your audio to **16kHz 16-bit mono PCM** format if needed:
-```bash
-$ ffmpeg -i <input_audio_path> -ar 16000 -ac 1 -acodec pcm_s16le -f wav <output_wav_path>
-```
+
+    ```bash
+    ffmpeg -i <input_audio_path> -ar 16000 -ac 1 -acodec pcm_s16le -f wav <output_wav_path>
+    ```
 
 ### Script Usage
+
 ```bash
-$ cd examples
-$ bash inference_vad.sh
-$ bash inference_stream_vad.sh
-$ bash inference_aed.sh
+cd examples
+bash inference_vad.sh
+bash inference_stream_vad.sh
+bash inference_aed.sh
 ```
 
-
 ### Command-line Usage
+
 If installed via `pip install fireredvad`, use the `fireredvad` CLI directly:
+
 ```bash
 $ fireredvad --task vad --wav_path assets/hello_zh.wav --model_dir pretrained_models/FireRedVAD/VAD
 # #param of DetectModel <class 'fireredvad.core.detect_model.DetectModel'> is 588417 = 2.2 MB (float32)
@@ -114,12 +116,13 @@ $ aed.py --use_gpu 0 --model_dir pretrained_models/FireRedVAD/AED --smooth_windo
     --wav_path assets/event.wav --output out/aed.txt --save_segment_dir out/aed
 ```
 
-
 ### Python API Usage
+>
 > If installed via `pip install fireredvad`, no `PYTHONPATH` setup is needed.
 > For source installation, set up `PYTHONPATH` first: `export PYTHONPATH=$PWD/:$PYTHONPATH`
 
 #### Non-streaming VAD
+
 ```python
 from fireredvad import FireRedVad, FireRedVadConfig
 
@@ -140,7 +143,6 @@ result, probs = vad.detect("assets/hello_zh.wav")
 print(result)
 # {'dur': 2.32, 'timestamps': [(0.44, 1.82)], 'wav_path': 'assets/hello_zh.wav'}
 ```
-
 
 #### Streaming VAD
 
@@ -163,7 +165,6 @@ frame_results, result = stream_vad.detect_full("assets/hello_en.wav")
 print(result)
 # {'dur': 2.24, 'timestamps': [(0.28, 1.83)], 'wav_path': 'assets/hello_en.wav'}
 ```
-
 
 #### Non-streaming AED
 
@@ -190,15 +191,14 @@ print(result)
 # {'dur': 22.016, 'event2timestamps': {'speech': [(0.4, 3.56), (3.66, 9.08), (9.27, 9.77), (10.78, 21.76)], 'singing': [(1.79, 19.96), (19.97, 22.016)], 'music': [(0.09, 12.32), (12.33, 22.016)]}, 'event2ratio': {'speech': 0.848, 'singing': 0.905, 'music': 0.991}, 'wav_path': 'assets/event.wav'}
 ```
 
-
-
 ## Method
+
 DFSMN-based non-streaming/streaming Voice Activity Detection and Audio Event Detection.
 
-
-
 ## Evaluation
+
 ### FireRedVAD
+
 We evaluate FireRedVAD on FLEURS-VAD-102, a multilingual VAD benchmark covering 102 languages.
 
 FireRedVAD achieves SOTA performance, outperforming Silero-VAD, TEN-VAD, FunASR-VAD, and WebRTC-VAD.
@@ -214,17 +214,18 @@ FireRedVAD achieves SOTA performance, outperforming Silero-VAD, TEN-VAD, FunASR-
 
 Note: FunASR-VAD achieves low Miss Rate but at the cost of high False Alarm Rate (44.03%), indicating over-prediction of speech segments.
 
-## Runtime 
+## Runtime
+
 Now support NCNN for multiplatform, see [runtime](runtime)
 
-
 ## FAQ
+
 **Q: What audio format is supported?**
 
 16kHz 16-bit mono PCM wav. Use ffmpeg to convert other formats: `ffmpeg -i <input_audio_path> -ar 16000 -ac 1 -acodec pcm_s16le -f wav <output_wav_path>`
 
-
 ## Citation
+
 ```bibtex
 @article{xu2026fireredasr2s,
   title={FireRedASR2S: A State-of-the-Art Industrial-Grade All-in-One Automatic Speech Recognition System},

--- a/requirements-macos-arm64.txt
+++ b/requirements-macos-arm64.txt
@@ -1,0 +1,7 @@
+Setuptools<81
+torch==2.1.0
+numpy==1.26.1
+kaldiio==2.18.0
+kaldi_native_fbank==1.21.3
+soundfile==0.12.1
+textgrid


### PR DESCRIPTION
## Problem faced
* **Installation Issue**: Broken installation due to incompatible dependencies.
* **Dependency Conflicts**: `torch==2.1.0+cu118` requires Nvidia CUDA and `kaldi_native_fbank` lacks a native macOS arm64 wheel.


## Before
<img width="1055" height="110" alt="image" src="https://github.com/user-attachments/assets/1d20bbeb-2399-489c-af11-61c4de69d5ee" />

- `pip install -r requirements.txt` failed on MacOS platform

## After
<img width="1452" height="639" alt="image" src="https://github.com/user-attachments/assets/0f7f749c-d5a2-4971-b836-542157110e76" />

https://github.com/user-attachments/assets/b94a5fda-4d50-49cb-aae0-4fd42f857e29

- `pip install -r requirements-macos-arm64.txt` resolves the installation error.

Closes #8.
